### PR TITLE
braker.pl : Fix key in ES gene length computation

### DIFF
--- a/scripts/braker.pl
+++ b/scripts/braker.pl
@@ -6362,12 +6362,13 @@ sub filter_genemark {
                 chomp;
                 my @l = split(/\t/);
                 $l[8] =~ m/transcript_id \"([^"]+)\"/;
-                push( @{$espred{$1}{'line'}}, $_ );
+                my $trid = $1;
+                push( @{$espred{$trid}{'line'}}, $_ );
                 if( $_ =~ m/\tCDS\t/ ) {
-                    if( !defined( $espred{$1}{'len'}) ) {
-                        $espred{$1}{'len'} = $l[4] - $l[3] + 1;
+                    if( !defined( $espred{$trid}{'len'}) ) {
+                        $espred{$trid}{'len'} = $l[4] - $l[3] + 1;
                     } else {
-                        $espred{$1}{'len'} += $l[4] - $l[3] + 1;
+                        $espred{$trid}{'len'} += $l[4] - $l[3] + 1;
                     }
                 }
             }


### PR DESCRIPTION
Value in $1 variable was being overwritten by a subsequent regex search for CDS
(related to issue https://github.com/Gaius-Augustus/BRAKER/issues/121)