### PR TITLE
Add missing argument for any evolutionary distance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1015,7 +1015,7 @@ Testing BRAKER with proteins of any evolutionary distance
 The following command will run the pipeline according to Figure [4](#fig3):
 
 
-    braker.pl --genome genome.fa --prot_seq proteins.fa --softmasking --cores N
+    braker.pl --genome genome.fa --epmode --prot_seq proteins.fa --softmasking --cores N
 
 
 This test is implemented in `test2.sh`, expected runtime is ~20 minutes.


### PR DESCRIPTION
Otherwise, BRAKER will complain about missing RNA-Seq or RNA hints file. According to your test2.sh file, a parameter was missing.

BRAKER output:
> No RNA-Seq or hints file(s) from RNA-Seq specified. Please set at least one RNAseq BAM file or at least one hints file from RNA-Seq (must contain intron hints from src b2h in column 2) to run BRAKER in mode for training from RNA-Seq.

Cheers

Roman Martin