### PR TITLE
Make downsampling of training genes deterministic

### DIFF
--- a/scripts/downsample_traingenes.pl
+++ b/scripts/downsample_traingenes.pl
@@ -126,7 +126,8 @@ my $min_single_exon_genes = 20;
 my $single_exon_gene_counter = 0;
 my %intronNumPrinted;
 
-while (my ($txid, $intronNum) = each %nIntrons ) {
+foreach my $txid (sort(keys %nIntrons)) {
+    my $intronNum = $nIntrons{$txid};
     if( $intronNum == 0 ) {
 	$single_exon_gene_counter++;
     }


### PR DESCRIPTION
The keys in a hash are not ordered. In some versions of Perl, the order of keys is consistent between runs but this is not guaranteed.