### PR TITLE
Fix for #334

### DIFF
--- a/scripts/braker.pl
+++ b/scripts/braker.pl
@@ -6124,6 +6124,7 @@ sub join_mult_hints {
             "$AUGUSTUS_CONFIG_PATH/species/$species", $useexisting,
             "ERROR in file " . __FILE__ ." at line ". __LINE__
             . "\nFailed to execute: $cmdString\n");
+        return;
     }else{
         print LOG "\# " . (localtime) . ": Joining hints that are identical "
             . "(& from the same source) into multiplicity hints (input file "


### PR DESCRIPTION
It is not necessary to check whether both `$to_be_merged` and `$not_to_be_merged` are empty since this is already covered in https://github.com/Gaius-Augustus/BRAKER/blob/e56d0398617a5751ff9f0d49418e08a8ed15154e/scripts/braker.pl#L5618