### PR TITLE
Fix filterGenemark.pl example to use --hints instead of --introns

### DIFF
--- a/scripts/filterGenemark.pl
+++ b/scripts/filterGenemark.pl
@@ -101,7 +101,7 @@ DESCRIPTION
 
 Example:
 
-filterGenemark.pl [OPTIONS] --genemark=genemark.gtf --introns=introns.gff
+filterGenemark.pl [OPTIONS] --genemark=genemark.gtf --hints=hints.gff
 
 ENDUSAGE
 


### PR DESCRIPTION
The filterGenemark.pl script provides an example using a (nonexistent) `--introns` option: 
https://github.com/Gaius-Augustus/BRAKER/blob/21d749e9f2dd8b216a40ec45e963e27c4759d9bd/scripts/filterGenemark.pl#L102-L104
It apparently should be `--hints=hints.gff`.