### PR TITLE
Remove unused Perl modules File::HomeDir and List::MoreUtils

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,12 +255,10 @@ conda install -c bioconda perl-class-data-inheritable
 conda install -c bioconda perl-exception-class
 conda install -c bioconda perl-test-pod
 conda install -c anaconda biopython
-conda install -c bioconda perl-file-homedir
 conda install -c bioconda perl-file-which # skip if you are not comparing to reference annotation
 conda install -c bioconda perl-mce
 conda install -c bioconda perl-threaded
 conda install -c bioconda perl-list-util
-conda install -c bioconda perl-list-moreutils
 conda install -c bioconda perl-math-utils
 conda install -c bioconda cdbtools
 ```

--- a/scripts/braker.pl
+++ b/scripts/braker.pl
@@ -19,7 +19,6 @@
 
 use Getopt::Long;
 use File::Compare;
-use File::HomeDir;
 use File::Copy;
 use File::Path qw(make_path rmtree);
 use Module::Load::Conditional qw(can_load check_install requires);
@@ -30,7 +29,6 @@ use Parallel::ForkManager;
 use FindBin;
 use lib "$FindBin::RealBin/.";
 use File::Which;                    # exports which()
-use List::MoreUtils qw( pairwise );
 use File::Which qw(which where);    # exports which() and where()
 
 use Cwd;
@@ -3619,7 +3617,7 @@ sub check_upfront {
         "Scalar::Util::Numeric", "POSIX", "List::Util",
         "FindBin", "File::Which", "Cwd", "File::Spec::Functions",
         "File::Basename", "File::Copy", "Term::ANSIColor",
-        "strict", "warnings", "File::HomeDir", "List::MoreUtils",
+        "strict", "warnings",
         "Math::Utils"
     );
 


### PR DESCRIPTION
braker.pl imports (but does not use) non-core Perl modules File::HomeDir and List::MoreUtils. This PR suggests removing their respective `use` statements to lighten the user-installed Perl module dependency burden a bit.