### PR TITLE
within set_JAVA_PATH, generalize check for java version and prevent substitutions within awk command

### DIFF
--- a/scripts/braker.pl
+++ b/scripts/braker.pl
@@ -2341,7 +2341,7 @@ sub set_JAVA_PATH {
     $JAVA_PATH = set_software_PATH($java_path, "JAVA_PATH",
                     \@required_files, 'exit');
 
-    $cmdString = "java -version 2>&1 | grep 'openjdk version' | awk -F['\"''.'] -v OFS=. '{print $2,$3}'";
+    $cmdString = "java -version 2>&1 | grep 'version' | awk -F['\"''.'] -v OFS=. ".'\'{print $2,$3}\'';
     my @javav = `$cmdString` or die("Failed to execute: $cmdString");
     if(not ($javav[0] =~ m/1\.8/ )){
         $prtStr = "\# " . (localtime) . " ERROR: in file " . __FILE__


### PR DESCRIPTION
Within `set_JAVA_PATH`, generalizes the check for java version to `grep` just for `version` (e.g., our system java is not OpenJDK) and fences off the awk command within single quotes to prevent substitution of the contained `$2,$3` with empty values that occurred because the surrounding context was double quotes.