### PR TITLE
fix for using other openjdk java (e.g. Zulu from Azul)

### DIFF
--- a/scripts/braker.pl
+++ b/scripts/braker.pl
@@ -2341,7 +2341,7 @@ sub set_JAVA_PATH {
     $JAVA_PATH = set_software_PATH($java_path, "JAVA_PATH",
                     \@required_files, 'exit');
 
-    $cmdString = "java -version 2>&1 | grep 'version' | awk -F['\"''.'] -v OFS=. ".'\'{print $2,$3}\'';
+    $cmdString = "java -version 2>&1 | awk -F['\"''.'] -v OFS=. '/version/ {print $2,$3}'";
     my @javav = `$cmdString` or die("Failed to execute: $cmdString");
     if(not ($javav[0] =~ m/1\.8/ )){
         $prtStr = "\# " . (localtime) . " ERROR: in file " . __FILE__


### PR DESCRIPTION
We are using openjdk from azul (zulu). In order to make braker.pl work, the attached patch had to be applied. 
It still works with standard openjdk java.

Please consider merging this 